### PR TITLE
Adding new addon from Curse failing

### DIFF
--- a/firestorm/js/search.js
+++ b/firestorm/js/search.js
@@ -48,7 +48,7 @@ function SearchViewModel(g) {
             discovered({
                 type: "curse",
                 name: m[1],
-                url: "http://mods.curse.com/addons/wow/" + m[1]
+                url: "https://mods.curse.com/addons/wow/" + m[1]
             });
             done();
         } else {

--- a/firestorm/js/search.js
+++ b/firestorm/js/search.js
@@ -43,12 +43,12 @@ function SearchViewModel(g) {
     };
 
     self.probe_curse = function(url, discovered, done) {
-        var m = /^http:\/\/www\.curse\.com\/addons\/wow\/([^\/]*)(\/.*)?/.exec(url);
+        var m = /^https:\/\/mods\.curse\.com\/addons\/wow\/([^\/]*)(\/.*)?/.exec(url);
         if (m !== null) {
             discovered({
                 type: "curse",
                 name: m[1],
-                url: "http://www.curse.com/addons/wow/" + m[1]
+                url: "http://mods.curse.com/addons/wow/" + m[1]
             });
             done();
         } else {


### PR DESCRIPTION
It looks like Curse modified their URLS from `www.curse` to `mods.curse`. They also appear to have moved to forced https.
